### PR TITLE
changes reduce to mirror js more fixes #3 #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,26 @@
-
 // *************
 // THE CHALLENGES
 // *************
 
-
-
 // ****************
 // 1 - write a recursive function that will console log each element of an array
 // ****************
-const logItAll = (arr) => {
- // ??
-}
-
+const logItAll = arr => {
+  // ??
+};
 
 // ****************
-// 2 - write a fuction that will recursively add the numbers from 1 to n 
+// 2 - write a function that will recursively add the numbers from 1 to n
 // ****************
 
 // recursiveSum :: Number -> Number
-const recursiveSum = (n) => {
+const recursiveSum = n => {
   // ???
-}
+};
 
 // console.log(recursiveSum(5)) // 15
 // console.log(recursiveSum(10)) // 55
 // console.log(recursiveSum(100)) // 5050
-
 
 // ****************
 // 3 - define a recursive map function - with data last style arguments
@@ -33,35 +28,34 @@ const recursiveSum = (n) => {
 
 // map :: (a -> b) -> [a] -> [b]
 const map = (f, arr) => {
- // ?
-}
+  // ?
+};
 
 // ****************
 // 4 - write a function that will return the nth fibonacci number
 // ****************
 
-const fib = (n) => { 
+const fib = n => {
   // ??
-}
+};
 
 // ****************
 // 5 - define a recursive reduce function - with data last style arguments :)
 // this will be hard. Read the type signature. <3
 // ****************
 
-// (a -> b -> b) -> b -> [a]
+// // (a -> b -> a) -> a -> [b] -> a
 const reduce = (f, acc, arr) => {
   // ??
-}
-
+};
 
 // ****************
 // 6 - define a recursive map function - using your reduce function!!
 // ****************
 
 const reduceMap = (f, arr) => {
-  return reduce(/* ??? */)
-}
+  return reduce(/* ??? */);
+};
 
 module.exports = {
   logItAll,
@@ -69,5 +63,5 @@ module.exports = {
   map,
   fib,
   reduce,
-  reduceMap,
-}
+  reduceMap
+};

--- a/solutions.js
+++ b/solutions.js
@@ -1,16 +1,18 @@
-const logItAll = (arr) => {
+const logItAll = arr => {
   if (arr.length <= 0) {
     return;
   }
   console.log(arr[0]);
   logItAll(arr.slice(1));
-}
+};
 
 // recursiveSum :: Number -> Number
-const recursiveSum = (n) => {
-  if (n === 0) { return 0 }
-  return n + recursiveSum(n - 1)
-}
+const recursiveSum = n => {
+  if (n === 0) {
+    return 0;
+  }
+  return n + recursiveSum(n - 1);
+};
 
 // map :: (a -> b) -> [a] -> [b]
 const map = (f, arr) => {
@@ -19,33 +21,30 @@ const map = (f, arr) => {
   } else {
     return [f(arr[0])].concat(map(f, arr.slice(1)));
   }
-}
+};
 
-const fib = (n) => { 
+const fib = n => {
   if (n === 0) {
     return n;
   } else if (n === 1) {
     return 1;
   }
   return fib(n - 1) + fib(n - 2);
-}
+};
 
-// (a -> b -> b) -> b -> [a]
+// (a -> b -> a) -> a -> [b] -> a
 const reduce = (f, acc, arr) => {
-  if (arr.length <= 0) {
-    return acc
+  if (arr.length === 0) {
+    return acc;
+  } else {
+    return reduce(f, f(acc, arr[0]), arr.slice(1));
   }
-  return f(arr[0], reduce(f, acc, arr.slice(1)))
-}
-
+};
 
 const reduceMap = (f, arr) => {
-  const accumulatorFunction = (a, b) => [f(a)].concat(b)
-  return reduce(accumulatorFunction, [], arr)
-}
-
-
-
+  const accumulatorFunction = (a, b) => a.concat(f(b));
+  return reduce(accumulatorFunction, [], arr);
+};
 
 module.exports = {
   logItAll,
@@ -53,5 +52,5 @@ module.exports = {
   map,
   fib,
   reduce,
-  reduceMap,
-}
+  reduceMap
+};

--- a/tests/reduce.test.js
+++ b/tests/reduce.test.js
@@ -2,17 +2,22 @@ const { reduce } = require('../index');
 
 describe('reduce', () => {
   it('can be used to sum an array', () => {
-    expect(reduce((a, b) => a + b, 0, [1,2,3,4])).toEqual(10);
+    expect(reduce((a, b) => a + b, 0, [1, 2, 3, 4])).toEqual(10);
   });
 
   it('can be used to filter an array', () => {
-    expect(reduce((a, b) => {
-      if (a.length === 3) {
-        return [a].concat(b)
-      } else {
-        return b
-      }
-    }, [], ["pumpkin", "pug", "po", "pof"]))
-      .toEqual(['pug', 'pof']);
+    expect(
+      reduce(
+        (a, b) => {
+          if (b.length === 3) {
+            return a.concat([b]);
+          } else {
+            return a;
+          }
+        },
+        [],
+        ['pumpkin', 'pug', 'po', 'pof']
+      )
+    ).toEqual(['pug', 'pof']);
   });
 });

--- a/tests/reduceMap.test.js
+++ b/tests/reduceMap.test.js
@@ -2,12 +2,14 @@ const { reduceMap } = require('../index');
 
 describe('map', () => {
   it('Can run add a number to all items in an array', () => {
-    expect(reduceMap(x => x + 1, [0,3,4]))
-      .toEqual([1,4,5]);
+    expect(reduceMap(x => x + 1, [0, 3, 4])).toEqual([1, 4, 5]);
   });
 
   it('Can uppercase all strings in an array', () => {
-    expect(reduceMap(x => x.toUpperCase(), ['the', 'moon', 'is']))
-      .toEqual(['THE', 'MOON', 'IS']);
+    expect(reduceMap(x => x.toUpperCase(), ['the', 'moon', 'is'])).toEqual([
+      'THE',
+      'MOON',
+      'IS'
+    ]);
   });
 });


### PR DESCRIPTION
changes reduce function to take `(acc, el)` rather than `(el, acc)`, updates type signature, changes tests and solution to reflect changes.

(also runs prettier on stuff, soz)
fix #4 
fix #3